### PR TITLE
ci: use GitHub Pages Actions for deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,20 +1,27 @@
-name: Deploy main to gh-pages
+name: Deploy site to GitHub Pages
 
 on:
   push:
     branches: [ 'main' ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: github-pages
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs
-          destination_dir: docs
-          keep_files: false
+          path: ./docs
+
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Use official GitHub Pages Actions to publish ./docs and add manual workflow_dispatch so repo Pages configured to 'GitHub Actions' can redeploy.\n\nThis replaces the peaceiris action with the official upload-pages-artifact + deploy-pages flow.